### PR TITLE
Assign a new (correct) layer id 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ImportLayersFromProject  plugin for QGIS 2.x
 ==================
 Import layers from another project, with all properties. Imports a disconnected copy of the layer(s), when Embed layers and groups keeps a live reference to it. 
-
+Bugtracker : http://hub.qgis.org/projects/menu-from-project
 
 
 ---- version Francaise ------
 Extension d'import de couches depuis un autre projet QGIS. A la différence de la fonction native qui réalise un lien dynamique vers les couches d'origine d'un autre projet, cette extension réalise une copie locale, modifiable mais non liée au projet d'origine.
+
+Signalement d'anomalies: http://hub.qgis.org/projects/menu-from-project

--- a/importLayersFromProject/LayerDialog.py
+++ b/importLayersFromProject/LayerDialog.py
@@ -3,6 +3,8 @@
 from PyQt4 import QtGui,QtCore, QtXml
 from PyQt4.QtGui import QTableWidgetItem
 
+from PyQt4.QtCore import QUuid
+
 from qgis.core import *
 from qgis.gui import *
 from LayerChooser import Ui_Layers
@@ -58,7 +60,24 @@ class LayerDialog(QtGui.QDialog, Ui_Layers):
                 index = int(index)
                 
                 print 'importproject debug. layerdialog.py line 50 index of checked layers: ' +str(index)
-                QgsProject.instance().read(self.maps.item(index))
+       
+                # noeud xml
+                layerNode = self.maps.item(index)
+                
+                # recherche id
+                idNode = layerNode.namedItem("id")
+                if idNode != None:
+                    id = idNode.firstChild().toText().data()
+                    # give it a new id (for multiple import)
+
+                    try:
+                        import re
+                        newLayerId = "L%s" % re.sub("[{}-]", "", QUuid.createUuid().toString())
+                        idNode.firstChild().toText().setData(newLayerId)
+                    except:
+                        pass
+              
+                QgsProject.instance().read(layerNode)
        
         QtCore.QDir.setCurrent(here)
         super(LayerDialog,self).accept()


### PR DESCRIPTION
to avoid duplicate layer id during multiple imports
